### PR TITLE
Support with MinimalApi for .NET +7

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,6 @@ This is a RateLimit that works with ActionFilters! An approach designed to contr
 
 Rate Limit uses **In-Memory** cache by default, but if you set up a **Redis** connection it will use Redis, it is recommended to use Redis for checking the rate limit in the distributed applications. By default, it limits the IP address but you can set ClientId in request headers and the header name is configurable.
 
-
-|TargetFramework|Support|
-|---|---|
-|**net8.0**|:white_check_mark:|
-|**net7.0**|:white_check_mark:|
-|**net6.0**|:white_check_mark:|
-|**net5.0**|:white_check_mark:|
-|**netcoreapp3.1**|:white_check_mark:|
-|**netstandard2.1**|:white_check_mark:|
-|**netstandard2.0**|:white_check_mark:|
-
 ## How to add in DI
 You can add RateLimit in Startup like this:
 ```csharp

--- a/demo/DotNet.RateLimiter.Demo/Controllers/RateLimitOnActionController.cs
+++ b/demo/DotNet.RateLimiter.Demo/Controllers/RateLimitOnActionController.cs
@@ -22,7 +22,7 @@ namespace DotNet.RateLimiter.Demo.Controllers
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = Random.Shared.Next(-20, 55),
+                Temperature = Random.Shared.Next(-20, 55),
                 Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             })
                 .ToArray();
@@ -40,7 +40,7 @@ namespace DotNet.RateLimiter.Demo.Controllers
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = Random.Shared.Next(-20, 55),
+                Temperature = Random.Shared.Next(-20, 55),
                 Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             })
                 .ToArray();
@@ -60,7 +60,7 @@ namespace DotNet.RateLimiter.Demo.Controllers
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = Random.Shared.Next(-20, 55),
+                Temperature = Random.Shared.Next(-20, 55),
                 Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             })
             .ToArray();
@@ -72,7 +72,7 @@ namespace DotNet.RateLimiter.Demo.Controllers
         /// </summary>
         /// <returns></returns>
         [HttpPut]
-        [RateLimit(PeriodInSec = 60, Limit = 3, BodyParams = "temperatureC")]
+        [RateLimit(PeriodInSec = 60, Limit = 3, BodyParams = "temperature")]
         public IActionResult Update([FromBody] WeatherForecast weatherForecast)
         {
             return Ok();

--- a/demo/DotNet.RateLimiter.Demo/Controllers/RateLimitOnAllController.cs
+++ b/demo/DotNet.RateLimiter.Demo/Controllers/RateLimitOnAllController.cs
@@ -21,7 +21,7 @@ namespace DotNet.RateLimiter.Demo.Controllers
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = Random.Shared.Next(-20, 55),
+                Temperature = Random.Shared.Next(-20, 55),
                 Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             })
                 .ToArray();
@@ -34,7 +34,7 @@ namespace DotNet.RateLimiter.Demo.Controllers
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = Random.Shared.Next(-20, 55),
+                Temperature = Random.Shared.Next(-20, 55),
                 Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             })
                 .ToArray();
@@ -46,7 +46,7 @@ namespace DotNet.RateLimiter.Demo.Controllers
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateTime.Now.AddDays(index),
-                TemperatureC = Random.Shared.Next(-20, 55),
+                Temperature = Random.Shared.Next(-20, 55),
                 Summary = Summaries[Random.Shared.Next(Summaries.Length)]
             })
             .ToArray();

--- a/demo/DotNet.RateLimiter.Demo/DotNet.RateLimiter.Demo.csproj
+++ b/demo/DotNet.RateLimiter.Demo/DotNet.RateLimiter.Demo.csproj
@@ -9,12 +9,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="DotNetRateLimiter" Version="1.0.8" />
+		<!--<PackageReference Include="DotNetRateLimiter" Version="1.0.8" />-->
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
 	</ItemGroup>
 
-	<!--<ItemGroup>
+	<ItemGroup>
 		<ProjectReference Include="..\..\src\DotNet.RateLimiter\DotNet.RateLimiter.csproj" />
-	</ItemGroup>-->
+	</ItemGroup>
 
 </Project>

--- a/demo/DotNet.RateLimiter.Demo/Program.cs
+++ b/demo/DotNet.RateLimiter.Demo/Program.cs
@@ -1,6 +1,7 @@
 using DotNet.RateLimiter;
 using DotNet.RateLimiter.Demo;
 using DotNet.RateLimiter.Extensions;
+using Microsoft.AspNetCore.Mvc;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -25,9 +26,9 @@ app.UseAuthorization();
 
 app.MapControllers();
 
-app.MapGet("/weatherforecast", () =>
+app.MapGet("/weatherforecast/{id}/{name}", (int id, string name, [FromQuery] string search, [FromQuery] int? age) =>
 {
-    return Results.Ok("Hi I'm here!");
+    return Results.Ok($"Hi I'm here! {id} - {name} - {search} - {age}");
 })
 .WithName("GetWeatherForecast")
 .WithRateLimiter(options =>

--- a/demo/DotNet.RateLimiter.Demo/Program.cs
+++ b/demo/DotNet.RateLimiter.Demo/Program.cs
@@ -30,11 +30,24 @@ app.MapGet("/weatherforecast/{id}/{name}", (int id, string name, [FromQuery] str
 {
     return Results.Ok($"Hi I'm here! {id} - {name} - {search} - {age}");
 })
-.WithName("GetWeatherForecast")
 .WithRateLimiter(options =>
 {
     options.PeriodInSec = 60;
     options.Limit = 2;
+    options.QueryParams = "search,age";
+    options.RouteParams = "id,name";
+});
+
+app.MapGet("/weatherforecast/{id}/{name}/another", (int id, string name, [FromQuery] string search, [FromQuery] int? age) =>
+{
+    return Results.Ok($"Hi I'm here! {id} - {name} - {search} - {age}");
+})
+.WithRateLimiter(options =>
+{
+    options.PeriodInSec = 60;
+    options.Limit = 2;
+    options.QueryParams = "search,age";
+    options.RouteParams = "id,name";
 });
 
 app.Run();

--- a/demo/DotNet.RateLimiter.Demo/Program.cs
+++ b/demo/DotNet.RateLimiter.Demo/Program.cs
@@ -1,4 +1,6 @@
 using DotNet.RateLimiter;
+using DotNet.RateLimiter.Demo;
+using DotNet.RateLimiter.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -22,5 +24,16 @@ app.UseHttpsRedirection();
 app.UseAuthorization();
 
 app.MapControllers();
+
+app.MapGet("/weatherforecast", () =>
+{
+    return Results.Ok("Hi I'm here!");
+})
+.WithName("GetWeatherForecast")
+.WithRateLimiter(options =>
+{
+    options.PeriodInSec = 60;
+    options.Limit = 2;
+});
 
 app.Run();

--- a/demo/DotNet.RateLimiter.Demo/WeatherForecast.cs
+++ b/demo/DotNet.RateLimiter.Demo/WeatherForecast.cs
@@ -4,9 +4,9 @@ namespace DotNet.RateLimiter.Demo
     {
         public DateTime Date { get; set; }
 
-        public int TemperatureC { get; set; }
+        public int Temperature { get; set; }
 
-        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+        public int TemperatureF => 32 + (int)(Temperature / 0.5556);
 
         public string Summary { get; set; }
     }

--- a/demo/DotNet.RateLimiter.Demo/appsettings.json
+++ b/demo/DotNet.RateLimiter.Demo/appsettings.json
@@ -11,7 +11,8 @@
     "HttpStatusCode": 429, //Optional: default is 429
     "ErrorMessage": "Rate limit Exceeded", //Optional: default is Rate limit Exceeded
     "IpHeaderName": "X-Forwarded-For" //Optional: header name for getting Ip address, default is X-Forwarded-For
-    //,"RedisConnection": "127.0.0.1:6379"
+    ,
+    "RedisConnection": "127.0.0.1:6379"
     //"IpWhiteList": ["::1"],
     //"ClientIdentifier": "X-Client-Id" // for getting client id from request header if this present the rate limit will not use IP for limit requests
     //"ClientIdentifierWhiteList": ["test-client"]

--- a/src/DotNet.RateLimiter/ActionFilters/IgnoreRateLimitAttribute.cs
+++ b/src/DotNet.RateLimiter/ActionFilters/IgnoreRateLimitAttribute.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 namespace DotNet.RateLimiter.ActionFilters
 {
     /// <summary>
-    /// using for ignore rate limit
+    /// Use for ignoring rate limit
     /// </summary>
     public class IgnoreRateLimitAttribute : Attribute, IIgnoreRateLimitFilter { }
 

--- a/src/DotNet.RateLimiter/ActionFilters/RateLimitAttribute.cs
+++ b/src/DotNet.RateLimiter/ActionFilters/RateLimitAttribute.cs
@@ -29,7 +29,7 @@ namespace DotNet.RateLimiter.ActionFilters
 
         public int Order { get; set; }
 
-        public RateLimitAttributeParams RateLimitParams { get; set; }
+        public RateLimitParams RateLimitParams { get; set; }
 
         public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
         {

--- a/src/DotNet.RateLimiter/ActionFilters/RateLimitAttribute.cs
+++ b/src/DotNet.RateLimiter/ActionFilters/RateLimitAttribute.cs
@@ -17,163 +17,40 @@ namespace DotNet.RateLimiter.ActionFilters
 {
     public class RateLimitAttribute : IAsyncActionFilter, IOrderedFilter
     {
-        private readonly ILogger<RateLimitAttribute> _logger;
-        private readonly IRateLimitService _rateLimitService;
         private readonly IOptions<RateLimitOptions> _options;
+        private readonly IRateLimitCoordinator _rateLimitCoordinator;
 
-        public RateLimitAttribute(ILogger<RateLimitAttribute> logger, IRateLimitService rateLimitService, IOptions<RateLimitOptions> options)
+        public RateLimitAttribute(IOptions<RateLimitOptions> options,
+            IRateLimitCoordinator rateLimitCoordinator)
         {
-            _logger = logger;
-            _rateLimitService = rateLimitService;
             _options = options;
+            _rateLimitCoordinator = rateLimitCoordinator;
         }
 
         public int Order { get; set; }
-        public int PeriodInSec { get; set; }
-        public int Limit { get; set; }
-        public string RouteParams { get; set; }
-        public string QueryParams { get; set; }
-        public string BodyParams { get; set; }
-        public RateLimitScope Scope { get; set; }
+
+        public RateLimitAttributeParams RateLimitParams { get; set; }
 
         public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
         {
-            try
-            {
-                //bypass request if rate limit was disable
-                if (!_options.Value.EnableRateLimit)
-                {
-                    await next.Invoke();
-                    return;
-                }
+            var goodToGo = await _rateLimitCoordinator.CheckRateLimitAsync(context, RateLimitParams);
 
-                //get current user IP based on header name
-                var userIp = context.HttpContext.Request.GetUserIp(_options.Value.IpHeaderName)?.ToString();
-
-                //skip rate limit if IP is in white list
-                if (_options.Value.IpWhiteList.Contains(userIp))
-                {
-                    await next.Invoke();
-                    return;
-                }
-
-                var requestKey = userIp;
-
-                if (!string.IsNullOrWhiteSpace(_options.Value.ClientIdentifier) &&
-                    context.HttpContext.Request.Headers.TryGetValue(_options.Value.ClientIdentifier, out var clientId))
-                {
-                    //skip rate limit for client identifiers in white list
-                    if (_options.Value.ClientIdentifierWhiteList.Contains(clientId))
-                    {
-                        await next.Invoke();
-                        return;
-                    }
-
-                    requestKey = clientId.ToString();
-                }
-
-                //if action had ignored rate limit then skip it
-                var filters = context.Filters;
-                if (filters.OfType<IIgnoreRateLimitFilter>().Any())
-                {
-                    await next.Invoke();
-                    return;
-                }
-
-                var rateLimitKey = ProvideRateLimitKey(context, requestKey);
-
-                var hasAccess = await _rateLimitService.HasAccessAsync(rateLimitKey, PeriodInSec, Limit);
-
-                if (!hasAccess)
-                {
-                    context.HttpContext.Response.StatusCode = _options.Value.HttpStatusCode;
-
-                    context.HttpContext.Response.ContentType = "application/json";
-
-                    var response = new RateLimitResponse()
-                    {
-                        Code = _options.Value.HttpStatusCode,
-                        Message = _options.Value.ErrorMessage
-                    };
-
-                    await context.HttpContext.Response.WriteAsync(JsonConvert.SerializeObject(response));
-                }
-                else
-                    await next.Invoke();
-            }
-            catch (Exception e)
-            {
-                _logger.LogCritical(e, e.Message);
+            if (goodToGo)
                 await next.Invoke();
-            }
-        }
-
-        private string ProvideRateLimitKey(ActionExecutingContext context, string requestKey)
-        {
-            context.ActionDescriptor.RouteValues.TryGetValue("Controller", out var controller);
-            context.ActionDescriptor.RouteValues.TryGetValue("Action", out var action);
-
-            var rateLimitKey = new StringBuilder();
-
-            rateLimitKey.Append(requestKey).Append(":").Append(controller);
-
-            //if scope is action then add action name to the key to consider each action separately
-            if (Scope == RateLimitScope.Action)
-                rateLimitKey.Append(action);
-
-            if (!string.IsNullOrWhiteSpace(RouteParams))
+            else
             {
-                var parameters = RouteParams.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-                foreach (var parameter in parameters)
+                context.HttpContext.Response.StatusCode = _options.Value.HttpStatusCode;
+
+                context.HttpContext.Response.ContentType = "application/json";
+
+                var response = new RateLimitResponse()
                 {
-                    if (context.HttpContext.GetRouteData().Values.TryGetValue(parameter, out var routeValue))
-                        rateLimitKey.Append(routeValue);
-                }
+                    Code = _options.Value.HttpStatusCode,
+                    Message = _options.Value.ErrorMessage
+                };
+
+                await context.HttpContext.Response.WriteAsync(JsonConvert.SerializeObject(response));
             }
-
-            if (!string.IsNullOrWhiteSpace(QueryParams))
-            {
-                var parameters = QueryParams.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-                foreach (var parameter in parameters)
-                {
-                    if (context.HttpContext.Request.Query.TryGetValue(parameter, out _))
-                    {
-                        var items = context.HttpContext.Request.Query[parameter].ToArray();
-
-                        switch (items.Length)
-                        {
-                            case 0:
-                                continue;
-                            case 1:
-                                rateLimitKey.Append(items[0]).Append(":");
-                                break;
-                            default:
-                                rateLimitKey.Append(string.Join(":", items));
-                                break;
-                        }
-                    }
-                }
-            }
-
-            if (!string.IsNullOrWhiteSpace(BodyParams))
-            {
-                var parameters = BodyParams.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-                var jsonSerializer = JsonConvert.SerializeObject(context.ActionArguments);
-                var obj = JObject.Parse(jsonSerializer);
-
-                foreach (var parameter in parameters)
-                {
-                    var rootProperty = obj.Root.First().Values().FirstOrDefault(x => x.Type == JTokenType.Property
-                             && string.Equals(((JProperty)x).Name, parameter, StringComparison.OrdinalIgnoreCase));
-
-                    if (rootProperty is JProperty property)
-                    {
-                        rateLimitKey.Append(property.Value).Append(":");
-                    }
-                }
-            }
-
-            return rateLimitKey.ToString();
         }
     }
 }

--- a/src/DotNet.RateLimiter/ActionFilters/RateLimitAttribute.cs
+++ b/src/DotNet.RateLimiter/ActionFilters/RateLimitAttribute.cs
@@ -110,18 +110,16 @@ namespace DotNet.RateLimiter.ActionFilters
 
         private string ProvideRateLimitKey(ActionExecutingContext context, string requestKey)
         {
-            //get controller and action name
             context.ActionDescriptor.RouteValues.TryGetValue("Controller", out var controller);
             context.ActionDescriptor.RouteValues.TryGetValue("Action", out var action);
 
-            //var rateLimitKey = $"{requestKey}:{controller}";
             var rateLimitKey = new StringBuilder();
 
             rateLimitKey.Append(requestKey).Append(":").Append(controller);
+
             //if scope is action then add action name to the key to consider each action separately
             if (Scope == RateLimitScope.Action)
                 rateLimitKey.Append(action);
-
 
             if (!string.IsNullOrWhiteSpace(RouteParams))
             {
@@ -150,19 +148,18 @@ namespace DotNet.RateLimiter.ActionFilters
                                 rateLimitKey.Append(items[0]).Append(":");
                                 break;
                             default:
-                                // rateLimitKey.AppendJoin(':',items); Not support in dotnet standard 2.0
                                 rateLimitKey.Append(string.Join(":", items));
                                 break;
                         }
                     }
                 }
             }
+
             if (!string.IsNullOrWhiteSpace(BodyParams))
             {
                 var parameters = BodyParams.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 var jsonSerializer = JsonConvert.SerializeObject(context.ActionArguments);
                 var obj = JObject.Parse(jsonSerializer);
-
 
                 foreach (var parameter in parameters)
                 {
@@ -175,6 +172,7 @@ namespace DotNet.RateLimiter.ActionFilters
                     }
                 }
             }
+
             return rateLimitKey.ToString();
         }
     }

--- a/src/DotNet.RateLimiter/ActionFilters/RateLimitFilterFactory.cs
+++ b/src/DotNet.RateLimiter/ActionFilters/RateLimitFilterFactory.cs
@@ -46,7 +46,7 @@ namespace DotNet.RateLimiter.ActionFilters
         {
             var filter = serviceProvider.GetRequiredService<RateLimitAttribute>();
             filter.Order = Order;
-            filter.RateLimitParams = new Models.RateLimitAttributeParams
+            filter.RateLimitParams = new Models.RateLimitParams
             {
                 Scope = Scope,
                 Limit = Limit,

--- a/src/DotNet.RateLimiter/ActionFilters/RateLimitFilterFactory.cs
+++ b/src/DotNet.RateLimiter/ActionFilters/RateLimitFilterFactory.cs
@@ -46,12 +46,15 @@ namespace DotNet.RateLimiter.ActionFilters
         {
             var filter = serviceProvider.GetRequiredService<RateLimitAttribute>();
             filter.Order = Order;
-            filter.PeriodInSec = PeriodInSec;
-            filter.Limit = Limit;
-            filter.RouteParams = RouteParams;
-            filter.QueryParams = QueryParams;
-            filter.BodyParams = BodyParams;
-            filter.Scope = Scope;
+            filter.RateLimitParams = new Models.RateLimitAttributeParams
+            {
+                Scope = Scope,
+                Limit = Limit,
+                PeriodInSec = PeriodInSec,
+                RouteParams = RouteParams,
+                BodyParams = BodyParams,
+                QueryParams = QueryParams
+            };
 
             return filter;
         }

--- a/src/DotNet.RateLimiter/ActionFilters/RateLimitFilterFactory.cs
+++ b/src/DotNet.RateLimiter/ActionFilters/RateLimitFilterFactory.cs
@@ -13,12 +13,12 @@ namespace DotNet.RateLimiter.ActionFilters
         public int Order { get; set; }
 
         /// <summary>
-        /// period of time in seconds for rate limit
+        /// Required - period of time in seconds for rate limit
         /// </summary>
         public int PeriodInSec { get; set; }
 
         /// <summary>
-        /// limit of requests
+        /// Required - Number of requests in the period to be allowed
         /// </summary>
         public int Limit { get; set; }
 

--- a/src/DotNet.RateLimiter/DotNet.RateLimiter.csproj
+++ b/src/DotNet.RateLimiter/DotNet.RateLimiter.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.1;netstandard2.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+		<!--<TargetFrameworks>net8.0</TargetFrameworks>-->
 		<AssemblyName>DotNet.RateLimiter</AssemblyName>
 		<RootNamespace>DotNet.RateLimiter</RootNamespace>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/DotNet.RateLimiter/EndPointFilters/RateLimitEndPointFilter.cs
+++ b/src/DotNet.RateLimiter/EndPointFilters/RateLimitEndPointFilter.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 
 namespace DotNet.RateLimiter.EndPointFilters;
 
+#if NET7_0_OR_GREATER
 public class RateLimitEndPointFilter : IEndpointFilter
 {
     private readonly IOptions<RateLimitOptions> _options;
@@ -42,3 +43,5 @@ public class RateLimitEndPointFilter : IEndpointFilter
         }
     }
 }
+
+#endif

--- a/src/DotNet.RateLimiter/EndPointFilters/RateLimitEndPointFilter.cs
+++ b/src/DotNet.RateLimiter/EndPointFilters/RateLimitEndPointFilter.cs
@@ -1,0 +1,44 @@
+﻿using DotNet.RateLimiter.Interfaces;
+using DotNet.RateLimiter.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using System;
+using System.Threading.Tasks;
+
+namespace DotNet.RateLimiter.EndPointFilters;
+
+public class RateLimitEndPointFilter : IEndpointFilter
+{
+    private readonly IOptions<RateLimitOptions> _options;
+    private readonly IRateLimitCoordinator _rateLimitCoordinator;
+
+    public RateLimitEndPointFilter(IOptions<RateLimitOptions> options,
+        IRateLimitCoordinator rateLimitCoordinator)
+    {
+        _options = options;
+        _rateLimitCoordinator = rateLimitCoordinator;
+    }
+
+    public async ValueTask<object> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        var rateLimitParams = context.HttpContext.Features.Get<RateLimitEndPointParams>();
+
+        ArgumentNullException.ThrowIfNull(nameof(rateLimitParams));
+
+        var goodToGo = await _rateLimitCoordinator.CheckRateLimitAsync(context, rateLimitParams);
+
+        if (goodToGo)
+            return await next(context);
+        else
+        {
+            var response = new RateLimitResponse()
+            {
+                Code = _options.Value.HttpStatusCode,
+                Message = _options.Value.ErrorMessage
+            };
+
+            return Results.Json(response, contentType: "application/json", statusCode: _options.Value.HttpStatusCode);
+        }
+    }
+}

--- a/src/DotNet.RateLimiter/Extensions/EndPointExtensions.cs
+++ b/src/DotNet.RateLimiter/Extensions/EndPointExtensions.cs
@@ -9,6 +9,7 @@ namespace DotNet.RateLimiter.Extensions
 {
     public static class EndPointExtensions
     {
+#if NET7_0_OR_GREATER
         public static TBuilder WithRateLimiter<TBuilder>(this TBuilder builder, Action<RateLimitEndPointParams> options)
             where TBuilder : IEndpointConventionBuilder
         {
@@ -40,5 +41,7 @@ namespace DotNet.RateLimiter.Extensions
 
             return builder;
         }
+#endif
+
     }
 }

--- a/src/DotNet.RateLimiter/Extensions/EndPointExtensions.cs
+++ b/src/DotNet.RateLimiter/Extensions/EndPointExtensions.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using DotNet.RateLimiter.EndPointFilters;
+using DotNet.RateLimiter.Models;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DotNet.RateLimiter.Extensions
+{
+    public static class EndPointExtensions
+    {
+        public static TBuilder WithRateLimiter<TBuilder>(this TBuilder builder, Action<RateLimitEndPointParams> options)
+            where TBuilder : IEndpointConventionBuilder
+        {
+            // We call `CreateFactory` twice here since the `CreateFactory` API does not support optional arguments.
+            // See https://github.com/dotnet/runtime/issues/67309 for more info.
+            ObjectFactory filterFactory;
+            try
+            {
+                filterFactory = ActivatorUtilities.CreateFactory(typeof(RateLimitEndPointFilter), new[] { typeof(EndpointFilterFactoryContext) });
+            }
+            catch (InvalidOperationException)
+            {
+                filterFactory = ActivatorUtilities.CreateFactory(typeof(RateLimitEndPointFilter), Type.EmptyTypes);
+            }
+
+            builder.AddEndpointFilterFactory((routeHandlerContext, next) =>
+            {
+                var invokeArguments = new[] { routeHandlerContext };
+                return (context) =>
+                {
+                    var opt = new RateLimitEndPointParams();
+                    options(opt);
+                    context.HttpContext.Features.Set(opt);
+
+                    var filter = (IEndpointFilter)filterFactory.Invoke(context.HttpContext.RequestServices, invokeArguments);
+                    return filter.InvokeAsync(context, next);
+                };
+            });
+
+            return builder;
+        }
+    }
+}

--- a/src/DotNet.RateLimiter/Extensions/HttpRequestExtension.cs
+++ b/src/DotNet.RateLimiter/Extensions/HttpRequestExtension.cs
@@ -8,12 +8,6 @@ namespace DotNet.RateLimiter.Extensions
 {
     public static class HttpRequestExtension
     {
-        /// <summary>
-        /// get current user Ip address based on header name
-        /// </summary>
-        /// <param name="request"></param>
-        /// <param name="headerName"></param>
-        /// <returns></returns>
         public static IPAddress GetUserIp(this HttpRequest request, string headerName)
         {
             if (request.Headers[headerName].FirstOrDefault() != null)
@@ -24,12 +18,6 @@ namespace DotNet.RateLimiter.Extensions
             return request.HttpContext.Connection.RemoteIpAddress;
         }
 
-        /// <summary>
-        /// get ip addresses
-        /// </summary>
-        /// <param name="ips"></param>
-        /// <param name="separator">ips separator(default is ',')</param>
-        /// <returns></returns>
         public static List<IPAddress> GetIpAddresses(this string ips, string separator = ",")
         {
             var ipAddresses = new List<IPAddress>();

--- a/src/DotNet.RateLimiter/Implementations/InMemoryRateLimitService.cs
+++ b/src/DotNet.RateLimiter/Implementations/InMemoryRateLimitService.cs
@@ -27,10 +27,6 @@ namespace DotNet.RateLimiter.Implementations
         {
             using (await _lockProvider.LockAsync(resourceKey).ConfigureAwait(false))
             {
-                //if limit set to 0 or less than zero so no need to check limit and block the request
-                if (limit <= 0)
-                    return false;
-
                 var cacheEntry = new InMemoryRateLimitEntry()
                 {
                     Expiration = DateTime.UtcNow,

--- a/src/DotNet.RateLimiter/Implementations/InMemoryRateLimitService.cs
+++ b/src/DotNet.RateLimiter/Implementations/InMemoryRateLimitService.cs
@@ -50,7 +50,7 @@ namespace DotNet.RateLimiter.Implementations
                         //rate limit exceeded
                         if (cacheEntry.Total >= limit)
                         {
-                            _logger.LogCritical($"Rate limit : key :{resourceKey} - count:{cacheEntry.Total}");
+                            _logger.LogCritical($"DotNet.RateLimiter:: key: {resourceKey} - count: {cacheEntry.Total}");
 
                             return false;
                         }

--- a/src/DotNet.RateLimiter/Implementations/InMemoryRateLimitService.cs
+++ b/src/DotNet.RateLimiter/Implementations/InMemoryRateLimitService.cs
@@ -13,6 +13,7 @@ namespace DotNet.RateLimiter.Implementations
         private readonly IMemoryCache _memoryCache;
         private readonly ILogger<InMemoryRateLimitService> _logger;
         private readonly AsyncKeyedLocker<string> _lockProvider;
+
         public InMemoryRateLimitService(IMemoryCache memoryCache,
             ILogger<InMemoryRateLimitService> logger,
             AsyncKeyedLocker<string> lockProvider)

--- a/src/DotNet.RateLimiter/Implementations/QueuedHostedService.cs
+++ b/src/DotNet.RateLimiter/Implementations/QueuedHostedService.cs
@@ -39,16 +39,9 @@ namespace DotNet.RateLimiter.Implementations
                 catch (Exception ex)
                 {
                     _logger.LogError(ex,
-                        "Error occurred executing {WorkItem}.", nameof(workItem));
+                        "DotNet.RateLimiter:: Error occurred executing {WorkItem}.", nameof(workItem));
                 }
             }
-        }
-
-        public override async Task StopAsync(CancellationToken stoppingToken)
-        {
-            _logger.LogInformation("Queued Hosted Service is stopping.");
-
-            await base.StopAsync(stoppingToken);
         }
     }
 }

--- a/src/DotNet.RateLimiter/Implementations/RateLimitCoordinator.cs
+++ b/src/DotNet.RateLimiter/Implementations/RateLimitCoordinator.cs
@@ -88,11 +88,12 @@ public class RateLimitCoordinator : IRateLimitCoordinator
         }
     }
 
+#if NET7_0_OR_GREATER
     public Task<bool> CheckRateLimitAsync(EndpointFilterInvocationContext context, RateLimitEndPointParams ratelimitParams)
     {
         return Task.FromResult(true);
     }
-
+#endif
     private string ProvideRateLimitKey(ActionExecutingContext context, RateLimitAttributeParams ratelimitParams, string requestKey)
     {
         context.ActionDescriptor.RouteValues.TryGetValue("Controller", out var controller);

--- a/src/DotNet.RateLimiter/Implementations/RateLimitCoordinator.cs
+++ b/src/DotNet.RateLimiter/Implementations/RateLimitCoordinator.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System;
 using System.Linq;
 using DotNet.RateLimiter.Extensions;
+using Microsoft.AspNetCore.Http;
 
 namespace DotNet.RateLimiter.Implementations;
 
@@ -40,6 +41,9 @@ public class RateLimitCoordinator : IRateLimitCoordinator
             {
                 return true;
             }
+
+            if (ratelimitParams.Limit <= 0)
+                return false;
 
             //get current user IP based on header name
             var userIp = context.HttpContext.Request.GetUserIp(_options.Value.IpHeaderName)?.ToString();
@@ -82,6 +86,11 @@ public class RateLimitCoordinator : IRateLimitCoordinator
             _logger.LogCritical(e, e.Message);
             return true;
         }
+    }
+
+    public Task<bool> CheckRateLimitAsync(EndpointFilterInvocationContext context, RateLimitEndPointParams ratelimitParams)
+    {
+        return Task.FromResult(true);
     }
 
     private string ProvideRateLimitKey(ActionExecutingContext context, RateLimitAttributeParams ratelimitParams, string requestKey)

--- a/src/DotNet.RateLimiter/Implementations/RateLimitCoordinator.cs
+++ b/src/DotNet.RateLimiter/Implementations/RateLimitCoordinator.cs
@@ -135,7 +135,7 @@ public class RateLimitCoordinator : IRateLimitCoordinator
             rateLimitKey
                 .Append(RateLimitPrefixKey)
                 .Append(context.HttpContext.Request.Method)
-                .Append(context.HttpContext.GetEndpoint().DisplayName);
+                .Append(context.HttpContext.GetEndpoint()?.DisplayName);
 
             ProvideRateLimitKey(context.HttpContext, rateLimitParams, rateLimitKey);
 

--- a/src/DotNet.RateLimiter/Implementations/RateLimitCoordinator.cs
+++ b/src/DotNet.RateLimiter/Implementations/RateLimitCoordinator.cs
@@ -1,0 +1,154 @@
+﻿using DotNet.RateLimiter.Interfaces;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Threading.Tasks;
+using DotNet.RateLimiter.Models;
+using Microsoft.AspNetCore.Routing;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
+using DotNet.RateLimiter.ActionFilters;
+using System.Text;
+using System;
+using System.Linq;
+using DotNet.RateLimiter.Extensions;
+
+namespace DotNet.RateLimiter.Implementations;
+
+public class RateLimitCoordinator : IRateLimitCoordinator
+{
+    private readonly ILogger<RateLimitCoordinator> _logger;
+    private readonly IRateLimitService _rateLimitService;
+    private readonly IOptions<RateLimitOptions> _options;
+
+    public RateLimitCoordinator(ILogger<RateLimitCoordinator> logger,
+        IRateLimitService rateLimitService,
+        IOptions<RateLimitOptions> options)
+    {
+        _logger = logger;
+        _rateLimitService = rateLimitService;
+        _options = options;
+    }
+
+
+    public async Task<bool> CheckRateLimitAsync(ActionExecutingContext context, RateLimitAttributeParams ratelimitParams)
+    {
+        try
+        {
+            //bypass request if rate limit was disable
+            if (!_options.Value.EnableRateLimit)
+            {
+                return true;
+            }
+
+            //get current user IP based on header name
+            var userIp = context.HttpContext.Request.GetUserIp(_options.Value.IpHeaderName)?.ToString();
+
+            //skip rate limit if IP is in white list
+            if (_options.Value.IpWhiteList.Contains(userIp))
+            {
+                return true;
+            }
+
+            var requestKey = userIp;
+
+            if (!string.IsNullOrWhiteSpace(_options.Value.ClientIdentifier) &&
+                context.HttpContext.Request.Headers.TryGetValue(_options.Value.ClientIdentifier, out var clientId))
+            {
+                //skip rate limit for client identifiers in white list
+                if (_options.Value.ClientIdentifierWhiteList.Contains(clientId))
+                {
+                    return true;
+                }
+
+                requestKey = clientId.ToString();
+            }
+
+            //if action had ignored rate limit then skip it
+            var filters = context.Filters;
+            if (filters.OfType<IIgnoreRateLimitFilter>().Any())
+            {
+                return true;
+            }
+
+            var rateLimitKey = ProvideRateLimitKey(context, ratelimitParams, requestKey);
+
+            return await _rateLimitService.HasAccessAsync(rateLimitKey, ratelimitParams.PeriodInSec, ratelimitParams.Limit);
+
+
+        }
+        catch (Exception e)
+        {
+            _logger.LogCritical(e, e.Message);
+            return true;
+        }
+    }
+
+    private string ProvideRateLimitKey(ActionExecutingContext context, RateLimitAttributeParams ratelimitParams, string requestKey)
+    {
+        context.ActionDescriptor.RouteValues.TryGetValue("Controller", out var controller);
+        context.ActionDescriptor.RouteValues.TryGetValue("Action", out var action);
+
+        var rateLimitKey = new StringBuilder();
+
+        rateLimitKey.Append(requestKey).Append(":").Append(controller);
+
+        //if scope is action then add action name to the key to consider each action separately
+        if (ratelimitParams.Scope == RateLimitScope.Action)
+            rateLimitKey.Append(action);
+
+        if (!string.IsNullOrWhiteSpace(ratelimitParams.RouteParams))
+        {
+            var parameters = ratelimitParams.RouteParams.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var parameter in parameters)
+            {
+                if (context.HttpContext.GetRouteData().Values.TryGetValue(parameter, out var routeValue))
+                    rateLimitKey.Append(routeValue);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(ratelimitParams.QueryParams))
+        {
+            var parameters = ratelimitParams.QueryParams.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var parameter in parameters)
+            {
+                if (context.HttpContext.Request.Query.TryGetValue(parameter, out _))
+                {
+                    var items = context.HttpContext.Request.Query[parameter].ToArray();
+
+                    switch (items.Length)
+                    {
+                        case 0:
+                            continue;
+                        case 1:
+                            rateLimitKey.Append(items[0]).Append(":");
+                            break;
+                        default:
+                            rateLimitKey.Append(string.Join(":", items));
+                            break;
+                    }
+                }
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(ratelimitParams.BodyParams))
+        {
+            var parameters = ratelimitParams.BodyParams.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            var jsonSerializer = JsonConvert.SerializeObject(context.ActionArguments);
+            var obj = JObject.Parse(jsonSerializer);
+
+            foreach (var parameter in parameters)
+            {
+                var rootProperty = obj.Root.First().Values().FirstOrDefault(x => x.Type == JTokenType.Property
+                         && string.Equals(((JProperty)x).Name, parameter, StringComparison.OrdinalIgnoreCase));
+
+                if (rootProperty is JProperty property)
+                {
+                    rateLimitKey.Append(property.Value).Append(":");
+                }
+            }
+        }
+
+        return rateLimitKey.ToString();
+    }
+}

--- a/src/DotNet.RateLimiter/Implementations/RateLimitCoordinator.cs
+++ b/src/DotNet.RateLimiter/Implementations/RateLimitCoordinator.cs
@@ -84,8 +84,8 @@ public class RateLimitCoordinator : IRateLimitCoordinator
             return (true, true, default);
         }
 
-        if (ratelimitParams.Limit <= 0)
-            return (true, false, default);
+        if (ratelimitParams.Limit <= 0 || ratelimitParams.PeriodInSec <= 0)
+            throw new ArgumentOutOfRangeException("PeriodInSec and Limit must be greater than 0 for RateLimiter");
 
         //get current user IP based on header name
         var userIp = httpContext.Request.GetUserIp(_options.Value.IpHeaderName)?.ToString();

--- a/src/DotNet.RateLimiter/Implementations/RedisRateLimitService.cs
+++ b/src/DotNet.RateLimiter/Implementations/RedisRateLimitService.cs
@@ -44,7 +44,7 @@ namespace DotNet.RateLimiter.Implementations
 
                 if (counts >= limit)
                 {
-                    _logger.LogCritical($"Rate limit : key :{resourceKey} - count:{counts}");
+                    _logger.LogCritical($"DotNet.RateLimiter:: key: {resourceKey} - count: {counts}");
 
                     return false;
                 }

--- a/src/DotNet.RateLimiter/Implementations/RedisRateLimitService.cs
+++ b/src/DotNet.RateLimiter/Implementations/RedisRateLimitService.cs
@@ -30,10 +30,6 @@ namespace DotNet.RateLimiter.Implementations
 
         public async Task<bool> HasAccessAsync(string resourceKey, int periodInSec, int limit)
         {
-            //if limit set to 0 or less than zero so no need to check limit and block the request
-            if (limit <= 0)
-                return false;
-
             await using var distributedLock = await _lockFactory.CreateLockAsync(resourceKey, _lockExpiry, _lockWait, _lockRetry);
 
             if (distributedLock.IsAcquired)

--- a/src/DotNet.RateLimiter/Interfaces/IRateLimitCoordinator.cs
+++ b/src/DotNet.RateLimiter/Interfaces/IRateLimitCoordinator.cs
@@ -1,4 +1,5 @@
 ﻿using DotNet.RateLimiter.Models;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Filters;
 using System.Threading.Tasks;
 
@@ -7,5 +8,7 @@ namespace DotNet.RateLimiter.Interfaces
     public interface IRateLimitCoordinator
     {
         Task<bool> CheckRateLimitAsync(ActionExecutingContext context, RateLimitAttributeParams ratelimitParams);
+
+        Task<bool> CheckRateLimitAsync(EndpointFilterInvocationContext context, RateLimitEndPointParams ratelimitParams);
     }
 }

--- a/src/DotNet.RateLimiter/Interfaces/IRateLimitCoordinator.cs
+++ b/src/DotNet.RateLimiter/Interfaces/IRateLimitCoordinator.cs
@@ -1,0 +1,11 @@
+﻿using DotNet.RateLimiter.Models;
+using Microsoft.AspNetCore.Mvc.Filters;
+using System.Threading.Tasks;
+
+namespace DotNet.RateLimiter.Interfaces
+{
+    public interface IRateLimitCoordinator
+    {
+        Task<bool> CheckRateLimitAsync(ActionExecutingContext context, RateLimitAttributeParams ratelimitParams);
+    }
+}

--- a/src/DotNet.RateLimiter/Interfaces/IRateLimitCoordinator.cs
+++ b/src/DotNet.RateLimiter/Interfaces/IRateLimitCoordinator.cs
@@ -7,7 +7,7 @@ namespace DotNet.RateLimiter.Interfaces
 {
     public interface IRateLimitCoordinator
     {
-        Task<bool> CheckRateLimitAsync(ActionExecutingContext context, RateLimitAttributeParams ratelimitParams);
+        Task<bool> CheckRateLimitAsync(ActionExecutingContext context, RateLimitParams ratelimitParams);
 
 #if NET7_0_OR_GREATER
         Task<bool> CheckRateLimitAsync(EndpointFilterInvocationContext context, RateLimitEndPointParams ratelimitParams);

--- a/src/DotNet.RateLimiter/Interfaces/IRateLimitCoordinator.cs
+++ b/src/DotNet.RateLimiter/Interfaces/IRateLimitCoordinator.cs
@@ -9,6 +9,8 @@ namespace DotNet.RateLimiter.Interfaces
     {
         Task<bool> CheckRateLimitAsync(ActionExecutingContext context, RateLimitAttributeParams ratelimitParams);
 
+#if NET7_0_OR_GREATER
         Task<bool> CheckRateLimitAsync(EndpointFilterInvocationContext context, RateLimitEndPointParams ratelimitParams);
+#endif
     }
 }

--- a/src/DotNet.RateLimiter/Interfaces/IRateLimitService.cs
+++ b/src/DotNet.RateLimiter/Interfaces/IRateLimitService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using Microsoft.AspNetCore.Mvc.Filters;
+using System.Threading.Tasks;
 
 namespace DotNet.RateLimiter.Interfaces
 {

--- a/src/DotNet.RateLimiter/Interfaces/IRateLimitService.cs
+++ b/src/DotNet.RateLimiter/Interfaces/IRateLimitService.cs
@@ -2,13 +2,10 @@
 
 namespace DotNet.RateLimiter.Interfaces
 {
-    /// <summary>
-    /// rate limit service
-    /// </summary>
     public interface IRateLimitService
     {
         /// <summary>
-        /// consider request can proceed or not based on key
+        /// consider request can proceed or not based on the given key
         /// </summary>
         /// <param name="resourceKey"></param>
         /// <param name="periodInSec"></param>

--- a/src/DotNet.RateLimiter/Models/RateLimitAttributeParams.cs
+++ b/src/DotNet.RateLimiter/Models/RateLimitAttributeParams.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DotNet.RateLimiter.Models;
+
+public class RateLimitAttributeParams
+{
+    public int PeriodInSec { get; set; }
+    public int Limit { get; set; }
+    public string RouteParams { get; set; }
+    public string QueryParams { get; set; }
+    public string BodyParams { get; set; }
+    public RateLimitScope Scope { get; set; }
+}

--- a/src/DotNet.RateLimiter/Models/RateLimitAttributeParams.cs
+++ b/src/DotNet.RateLimiter/Models/RateLimitAttributeParams.cs
@@ -35,9 +35,4 @@ public class RateLimitEndPointParams
     /// seek in query string parameters and check rate limit for specific params, for multiple parameters separate them by comma (,)
     /// </summary>
     public string QueryParams { get; set; }
-
-    /// <summary>
-    /// seek in body parameters and check rate limit for specific params, for multiple parameters separate them by comma (,)
-    /// </summary>
-    public string BodyParams { get; set; }
 }

--- a/src/DotNet.RateLimiter/Models/RateLimitAttributeParams.cs
+++ b/src/DotNet.RateLimiter/Models/RateLimitAttributeParams.cs
@@ -13,3 +13,31 @@ public class RateLimitAttributeParams
     public string BodyParams { get; set; }
     public RateLimitScope Scope { get; set; }
 }
+
+public class RateLimitEndPointParams
+{
+    /// <summary>
+    /// period of time in seconds for rate limit
+    /// </summary>
+    public int PeriodInSec { get; set; }
+
+    /// <summary>
+    /// limit of requests
+    /// </summary>
+    public int Limit { get; set; }
+
+    /// <summary>
+    /// seek in route parameters and check rate limit for specific params, for multiple parameters separate them by comma (,)
+    /// </summary>
+    public string RouteParams { get; set; }
+
+    /// <summary>
+    /// seek in query string parameters and check rate limit for specific params, for multiple parameters separate them by comma (,)
+    /// </summary>
+    public string QueryParams { get; set; }
+
+    /// <summary>
+    /// seek in body parameters and check rate limit for specific params, for multiple parameters separate them by comma (,)
+    /// </summary>
+    public string BodyParams { get; set; }
+}

--- a/src/DotNet.RateLimiter/Models/RateLimitOptions.cs
+++ b/src/DotNet.RateLimiter/Models/RateLimitOptions.cs
@@ -8,6 +8,7 @@ namespace DotNet.RateLimiter.Models
         {
             IpWhiteList = new List<string>();
         }
+
         /// <summary>
         /// if false will bypass all requests, default is true.
         /// </summary>

--- a/src/DotNet.RateLimiter/Models/RateLimitParams.cs
+++ b/src/DotNet.RateLimiter/Models/RateLimitParams.cs
@@ -17,12 +17,12 @@ public class RateLimitParams
 public class RateLimitEndPointParams
 {
     /// <summary>
-    /// period of time in seconds for rate limit
+    /// Required - period of time in seconds for rate limit
     /// </summary>
     public int PeriodInSec { get; set; }
 
     /// <summary>
-    /// limit of requests
+    /// Required - Number of requests in the period to be allowed
     /// </summary>
     public int Limit { get; set; }
 

--- a/src/DotNet.RateLimiter/Models/RateLimitParams.cs
+++ b/src/DotNet.RateLimiter/Models/RateLimitParams.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace DotNet.RateLimiter.Models;
 
-public class RateLimitAttributeParams
+public class RateLimitParams
 {
     public int PeriodInSec { get; set; }
     public int Limit { get; set; }

--- a/src/DotNet.RateLimiter/RateLimitScope.cs
+++ b/src/DotNet.RateLimiter/RateLimitScope.cs
@@ -3,12 +3,12 @@
     public enum RateLimitScope
     {
         /// <summary>
-        /// rate limit will work for each action
+        /// Rate limit will work on each action
         /// </summary>
         Action,
 
         /// <summary>
-        /// rate limit will work for entire controller no matter which action calls
+        /// Rate limit will work on the entire controller no matter which action calls
         /// </summary>
         Controller
     }

--- a/src/DotNet.RateLimiter/ServiceCollectionExtension.cs
+++ b/src/DotNet.RateLimiter/ServiceCollectionExtension.cs
@@ -19,6 +19,7 @@ namespace DotNet.RateLimiter
         {
             services.Configure<RateLimitOptions>(configuration.GetSection("RateLimitOption"));
             services.AddScoped<RateLimitAttribute>();
+            services.AddScoped<IRateLimitCoordinator, RateLimitCoordinator>();
 
             var options = new RateLimitOptions();
             configuration.GetSection("RateLimitOption").Bind(options);

--- a/test/DotNet.RateLimiter.Test/BaseRateLimitTest.cs
+++ b/test/DotNet.RateLimiter.Test/BaseRateLimitTest.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -167,12 +168,15 @@ public class BaseRateLimitTest
 
     [Theory]
     [MemberData(nameof(TestDataProvider.TooManyRequestTestDataWithBodyParams), MemberType = typeof(TestDataProvider))]
-    public async Task ExtraRequest_WithBodyParam_Returns_TooManyRequest(int limit, int periodInSec, Dictionary<string, object?> actionArguments, HttpStatusCode expectedResult)
+    public async Task ExtraRequest_WithBodyParam_Returns_TooManyRequest(int limit, int periodInSec,
+        Dictionary<string, object?> actionArguments, HttpStatusCode expectedResult)
     {
-        using var scope = _scopeFactory.CreateScope();
-        var rateLimitAction = TestInitializer.CreateRateLimitFilter(scope, limit, periodInSec, bodyParams: string.Join(",", actionArguments.Select(x => x.Key)));
 
-        var actionContext = TestInitializer.SetupActionContext(ip: TestInitializer.GetRandomIpAddress(), bodyParams: actionArguments);
+        using var scope = _scopeFactory.CreateScope();
+        var bodyParams = "id,name";
+        var rateLimitAction = TestInitializer.CreateRateLimitFilter(scope, limit, periodInSec, bodyParams);
+
+        var actionContext = TestInitializer.SetupActionContext(ip: TestInitializer.GetRandomIpAddress(), bodyParams: actionArguments!);
 
         var actionExecutingContext = new ActionExecutingContext(actionContext, new List<IFilterMetadata>(), actionArguments, null!);
 
@@ -183,16 +187,15 @@ public class BaseRateLimitTest
         actionExecutingContext.HttpContext.Response.StatusCode.Should().Be((int)expectedResult);
     }
 
-
-
     [Theory]
     [MemberData(nameof(TestDataProvider.OkTestDataWithBodyParams), MemberType = typeof(TestDataProvider))]
     public async Task NormalRequest_WithBodyParam_Returns_OK(int limit, int periodInSec, Dictionary<string, object?> actionArguments, HttpStatusCode expectedResult)
     {
         using var scope = _scopeFactory.CreateScope();
-        var rateLimitAction = TestInitializer.CreateRateLimitFilter(scope, limit, periodInSec, bodyParams: string.Join(",", actionArguments.Select(x => x.Key)));
+        var bodyParams = "id,name";
+        var rateLimitAction = TestInitializer.CreateRateLimitFilter(scope, limit, periodInSec, bodyParams);
 
-        var actionContext = TestInitializer.SetupActionContext(ip: TestInitializer.GetRandomIpAddress(), bodyParams: actionArguments);
+        var actionContext = TestInitializer.SetupActionContext(ip: TestInitializer.GetRandomIpAddress(), bodyParams: actionArguments!);
 
         var actionExecutingContext = new ActionExecutingContext(actionContext, new List<IFilterMetadata>(), actionArguments, null!);
 

--- a/test/DotNet.RateLimiter.Test/RateLimitCoordinatorTest.cs
+++ b/test/DotNet.RateLimiter.Test/RateLimitCoordinatorTest.cs
@@ -1,0 +1,26 @@
+﻿using DotNet.RateLimiter.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.DependencyInjection;
+
+namespace DotNet.RateLimiter.Test;
+
+[Startup(typeof(Startup))]
+public class RateLimitCoordinatorTest
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public RateLimitCoordinatorTest(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    [Fact]
+    public void TestMethod()
+    {
+        using var scope = _scopeFactory.CreateScope();
+
+        var rateLimitCoordinator = scope.ServiceProvider.GetRequiredService<IRateLimitCoordinator>();
+
+    }
+}

--- a/test/DotNet.RateLimiter.Test/RateLimitCoordinatorTest.cs
+++ b/test/DotNet.RateLimiter.Test/RateLimitCoordinatorTest.cs
@@ -1,5 +1,11 @@
 ﻿using DotNet.RateLimiter.Interfaces;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.DependencyInjection;
 
@@ -15,12 +21,146 @@ public class RateLimitCoordinatorTest
         _scopeFactory = scopeFactory;
     }
 
-    [Fact]
-    public void TestMethod()
+    [Theory]
+    [MemberData(nameof(TestDataProvider.TrueTestDataWithNoParams), MemberType = typeof(TestDataProvider))]
+    public async Task NormalRequest_WithNoParams_Returns_True(int limit, int periodInSec, bool expectedResult)
     {
         using var scope = _scopeFactory.CreateScope();
 
         var rateLimitCoordinator = scope.ServiceProvider.GetRequiredService<IRateLimitCoordinator>();
 
+        var endpointContext = TestInitializer.CreateEndPointContext();
+
+        var result = await rateLimitCoordinator.CheckRateLimitAsync(endpointContext, new Models.RateLimitEndPointParams
+        {
+            Limit = limit,
+            PeriodInSec = periodInSec
+        });
+
+        result.Should().Be(expectedResult);
+    }
+
+    [Theory]
+    [MemberData(nameof(TestDataProvider.FalseTestDataWithNoParams), MemberType = typeof(TestDataProvider))]
+    public async Task ManyRequest_WithNoParams_Returns_False(int limit, int periodInSec, bool expectedResult)
+    {
+        using var scope = _scopeFactory.CreateScope();
+
+        var rateLimitCoordinator = scope.ServiceProvider.GetRequiredService<IRateLimitCoordinator>();
+
+        var endpointContext = TestInitializer.CreateEndPointContext();
+
+        var result = await rateLimitCoordinator.CheckRateLimitAsync(endpointContext, new Models.RateLimitEndPointParams
+        {
+            Limit = limit,
+            PeriodInSec = periodInSec
+        });
+
+        result = await rateLimitCoordinator.CheckRateLimitAsync(endpointContext, new Models.RateLimitEndPointParams
+        {
+            Limit = limit,
+            PeriodInSec = periodInSec
+        });
+
+        result.Should().Be(expectedResult);
+    }
+
+    [Theory]
+    [MemberData(nameof(TestDataProvider.TrueTestDataWithRouteParams), MemberType = typeof(TestDataProvider))]
+    public async Task NormalRequest_WithRouteParam_Returns_True(int limit, int periodInSec, Dictionary<string, object?> routeParams, bool expectedResult)
+    {
+        using var scope = _scopeFactory.CreateScope();
+
+        var rateLimitCoordinator = scope.ServiceProvider.GetRequiredService<IRateLimitCoordinator>();
+
+        var endpointContext = TestInitializer.CreateEndPointContext(routeParams: routeParams);
+
+        var result = await rateLimitCoordinator.CheckRateLimitAsync(endpointContext, new Models.RateLimitEndPointParams
+        {
+            Limit = limit,
+            PeriodInSec = periodInSec,
+            RouteParams = string.Join(',', routeParams.Select(x=>x.Key))
+        });
+
+        result.Should().Be(expectedResult);
+    }
+
+    [Theory]
+    [MemberData(nameof(TestDataProvider.FalseTestDataWithRouteParams), MemberType = typeof(TestDataProvider))]
+    public async Task ManyRequest_WithRouteParam_Returns_False(int limit, int periodInSec, Dictionary<string, object?> routeParams, bool expectedResult)
+    {
+        using var scope = _scopeFactory.CreateScope();
+
+        var rateLimitCoordinator = scope.ServiceProvider.GetRequiredService<IRateLimitCoordinator>();
+
+        var endpointContext = TestInitializer.CreateEndPointContext(routeParams: routeParams);
+
+        var result = await rateLimitCoordinator.CheckRateLimitAsync(endpointContext, new Models.RateLimitEndPointParams
+        {
+            Limit = limit,
+            PeriodInSec = periodInSec,
+            RouteParams = string.Join(',', routeParams.Select(x => x.Key))
+        });
+
+        result = await rateLimitCoordinator.CheckRateLimitAsync(endpointContext, new Models.RateLimitEndPointParams
+        {
+            Limit = limit,
+            PeriodInSec = periodInSec,
+            RouteParams = string.Join(',', routeParams.Select(x => x.Key))
+        });
+
+        result.Should().Be(expectedResult);
+    }
+
+    [Theory]
+    [MemberData(nameof(TestDataProvider.TrueTestDataWithRouteAndQueryParams), MemberType = typeof(TestDataProvider))]
+    public async Task NormalRequest_WithRouteParam_QueryParam_Returns_True(int limit, int periodInSec, 
+        Dictionary<string, object?> routeParams, Dictionary<string, object?> queryParams, bool expectedResult)
+    {
+        using var scope = _scopeFactory.CreateScope();
+
+        var rateLimitCoordinator = scope.ServiceProvider.GetRequiredService<IRateLimitCoordinator>();
+
+        var endpointContext = TestInitializer.CreateEndPointContext(routeParams: routeParams, queryParams: queryParams);
+
+        var result = await rateLimitCoordinator.CheckRateLimitAsync(endpointContext, new Models.RateLimitEndPointParams
+        {
+            Limit = limit,
+            PeriodInSec = periodInSec,
+            RouteParams = string.Join(',', routeParams.Select(x => x.Key)),
+            QueryParams = string.Join(',', queryParams.Select(x=>x.Key))
+        });
+
+        result.Should().Be(expectedResult);
+    }
+
+    [Theory]
+    [MemberData(nameof(TestDataProvider.FalseTestDataWithRouteAndQueryParams), MemberType = typeof(TestDataProvider))]
+    public async Task ManyRequest_WithRouteParam_QueryParam_Returns_False(int limit, int periodInSec,
+        Dictionary<string, object?> routeParams, Dictionary<string, object?> queryParams, bool expectedResult)
+    {
+        using var scope = _scopeFactory.CreateScope();
+
+        var rateLimitCoordinator = scope.ServiceProvider.GetRequiredService<IRateLimitCoordinator>();
+
+        var endpointContext = TestInitializer.CreateEndPointContext(routeParams: routeParams, queryParams: queryParams);
+
+        var result = await rateLimitCoordinator.CheckRateLimitAsync(endpointContext, new Models.RateLimitEndPointParams
+        {
+            Limit = limit,
+            PeriodInSec = periodInSec,
+            RouteParams = string.Join(',', routeParams.Select(x => x.Key)),
+            QueryParams = string.Join(',', queryParams.Select(x => x.Key))
+        });
+
+        result = await rateLimitCoordinator.CheckRateLimitAsync(endpointContext, new Models.RateLimitEndPointParams
+        {
+            Limit = limit,
+            PeriodInSec = periodInSec,
+            RouteParams = string.Join(',', routeParams.Select(x => x.Key)),
+            QueryParams = string.Join(',', queryParams.Select(x => x.Key))
+        });
+
+        result.Should().Be(expectedResult);
     }
 }

--- a/test/DotNet.RateLimiter.Test/TestDataProvider.cs
+++ b/test/DotNet.RateLimiter.Test/TestDataProvider.cs
@@ -75,8 +75,7 @@ public class TestDataProvider
         {
             new object[] { 1, 60, new Dictionary<string, object?>()
             {
-                {"id","20"},
-                {"name","rate-limit"},
+                {"Model", new {Id = 20, Name = "rate-limit"} }
             }, HttpStatusCode.OK }
         };
 
@@ -86,8 +85,7 @@ public class TestDataProvider
         {
             new object[] { 1, 60, new Dictionary<string, object?>()
             {
-                {"id","20"},
-                {"name","rate-limit"}
+                {"Model", new {Id = 20, Name = "rate-limit"} }
             }, HttpStatusCode.TooManyRequests }
         };
 }

--- a/test/DotNet.RateLimiter.Test/TestDataProvider.cs
+++ b/test/DotNet.RateLimiter.Test/TestDataProvider.cs
@@ -12,6 +12,18 @@ public class TestDataProvider
             new object[] { 1, 60, new Dictionary<string, object?>(), HttpStatusCode.OK }
         };
 
+    public static IEnumerable<object[]> TrueTestDataWithNoParams =>
+       new List<object[]>
+       {
+            new object[] { 1, 60, true }
+       };
+
+    public static IEnumerable<object[]> FalseTestDataWithNoParams =>
+      new List<object[]>
+      {
+            new object[] { 1, 60, false }
+      };
+
     public static IEnumerable<object[]> TooManyRequestTestDataWithNoParams =>
         new List<object[]>
         {
@@ -26,6 +38,26 @@ public class TestDataProvider
                 {"id","20"},
                 {"name","rate-limit"},
             }, HttpStatusCode.OK }
+        };
+
+    public static IEnumerable<object[]> TrueTestDataWithRouteParams =>
+        new List<object[]>
+        {
+            new object[] { 1, 60, new Dictionary<string, object?>()
+            {
+                {"id","20"},
+                {"name","rate-limit"},
+            }, true }
+        };
+
+    public static IEnumerable<object[]> FalseTestDataWithRouteParams =>
+        new List<object[]>
+        {
+            new object[] { 1, 60, new Dictionary<string, object?>()
+            {
+                {"id","20"},
+                {"name","rate-limit"},
+            }, false }
         };
 
     public static IEnumerable<object[]> TooManyRequestTestDataWithRouteParams =>
@@ -53,6 +85,38 @@ public class TestDataProvider
                 }
                 , HttpStatusCode.OK }
         };
+
+    public static IEnumerable<object[]> TrueTestDataWithRouteAndQueryParams =>
+       new List<object[]>
+       {
+            new object[] { 1, 60, new Dictionary<string, object?>()
+                {
+                    {"id","20"},
+                    {"name","rate-limit"}
+                },
+                new Dictionary<string, object>()
+                {
+                    {"q1","query1"},
+                    {"q2","query2"}
+                }
+                , true }
+       };
+
+    public static IEnumerable<object[]> FalseTestDataWithRouteAndQueryParams =>
+       new List<object[]>
+       {
+            new object[] { 1, 60, new Dictionary<string, object?>()
+                {
+                    {"id","20"},
+                    {"name","rate-limit"}
+                },
+                new Dictionary<string, object>()
+                {
+                    {"q1","query1"},
+                    {"q2","query2"}
+                }
+                , false }
+       };
 
     public static IEnumerable<object[]> TooManyRequestTestDataWithRouteAndQueryParams =>
         new List<object[]>

--- a/test/DotNet.RateLimiter.Test/TestInitializer.cs
+++ b/test/DotNet.RateLimiter.Test/TestInitializer.cs
@@ -76,7 +76,7 @@ public class TestInitializer
             scopeFactory.ServiceProvider.GetRequiredService<IOptions<RateLimitOptions>>(),
             scopeFactory.ServiceProvider.GetRequiredService<IRateLimitCoordinator>())
         {
-            RateLimitParams = new RateLimitAttributeParams
+            RateLimitParams = new RateLimitParams
             {
                 BodyParams = bodyParams,
                 Limit = limit,

--- a/test/DotNet.RateLimiter.Test/TestInitializer.cs
+++ b/test/DotNet.RateLimiter.Test/TestInitializer.cs
@@ -48,7 +48,7 @@ public class TestInitializer
             }
 
 
-        return new ActionContext(httpContext,   
+        return new ActionContext(httpContext,
             new RouteData(),
             new ActionDescriptor()
             {
@@ -73,16 +73,18 @@ public class TestInitializer
         string? queryParams = null, string? bodyParams = null, RateLimitScope scope = RateLimitScope.Action)
     {
         return new RateLimitAttribute(
-            scopeFactory.ServiceProvider.GetRequiredService<ILogger<RateLimitAttribute>>(),
-            scopeFactory.ServiceProvider.GetRequiredService<IRateLimitService>(),
-            scopeFactory.ServiceProvider.GetRequiredService<IOptions<RateLimitOptions>>())
+            scopeFactory.ServiceProvider.GetRequiredService<IOptions<RateLimitOptions>>(),
+            scopeFactory.ServiceProvider.GetRequiredService<IRateLimitCoordinator>())
         {
-            Limit = limit,
-            PeriodInSec = periodInSec,
-            QueryParams = queryParams,
-            RouteParams = routeParams,
-            BodyParams = bodyParams,
-            Scope = scope
+            RateLimitParams = new RateLimitAttributeParams
+            {
+                BodyParams = bodyParams,
+                Limit = limit,
+                PeriodInSec = periodInSec,
+                RouteParams = routeParams,
+                QueryParams = queryParams,
+                Scope = scope
+            }
         };
     }
 


### PR DESCRIPTION
Adding support for MinimalApi for .NET +7, I use EndPointFilters which was added in .NET 7.
For now supports QueryParams and RouteParams but no BodyParams.

```csharp
app.MapGet("/weatherforecast/{id}/{name}", (int id, string name, [FromQuery] string search, [FromQuery] int? age) =>
{
    return Results.Ok($"Hi I'm here! {id} - {name} - {search} - {age}");
})
.WithRateLimiter(options =>
{
    options.PeriodInSec = 60;
    options.Limit = 2;
    options.QueryParams = "search,age";
    options.RouteParams = "id,name";
});
```