### PR TITLE
Fix: Use proper RedLockMultiplexer constructor instead of implicit casting

### DIFF
--- a/src/DotNet.RateLimiter/ServiceCollectionExtension.cs
+++ b/src/DotNet.RateLimiter/ServiceCollectionExtension.cs
@@ -48,7 +48,7 @@ namespace DotNet.RateLimiter
 
                     return RedLockFactory.Create(new List<RedLockMultiplexer>()
                     {
-                        ConnectionMultiplexer.Connect(config)
+                        new RedLockMultiplexer(ConnectionMultiplexer.Connect(config))
                     });
                 });
             }
@@ -89,7 +89,7 @@ namespace DotNet.RateLimiter
             {
                 return RedLockFactory.Create(new List<RedLockMultiplexer>()
                 {
-                        (ConnectionMultiplexer)connectionMultiplexer
+                        new RedLockMultiplexer(connectionMultiplexer)
                 });
             });
         }
@@ -120,7 +120,7 @@ namespace DotNet.RateLimiter
             {
                 return RedLockFactory.Create(new List<RedLockMultiplexer>()
                 {
-                        (ConnectionMultiplexer)multiplexer
+                        new RedLockMultiplexer(multiplexer)
                 });
             });
         }


### PR DESCRIPTION
The code was using implicit casting from `ConnectionMultiplexer` to `RedLockMultiplexer` in three locations, which could cause type safety issues and doesn't follow RedLock.net library best practices.
I Replaced all instances with proper `RedLockMultiplexer` constructor calls as recommended by the RedLock.net documentation.
This fix was discovered while testing the Redis integration improvements from #30.
